### PR TITLE
Ubiq has forked from Ethash to Ubqhash so it no longer vulnerable

### DIFF
--- a/crypto51/config.py
+++ b/crypto51/config.py
@@ -1,1 +1,1 @@
-coin_blacklist = set(['XDN', 'PPC', 'DGB', 'KMD', 'DCY', 'DP', 'NLG'])
+coin_blacklist = set(['XDN', 'PPC', 'DGB', 'KMD', 'DCY', 'DP', 'NLG', 'UBQ'])


### PR DESCRIPTION
Details:
https://blog.ubiqsmart.com/introducing-ubqhash-8fa515befd7
https://blog.ubiqsmart.com/announcing-the-uip-1-hard-fork-84d9b8b3b924