### PR TITLE
Removed EMC2 - has implemented dPoW

### DIFF
--- a/crypto51/config.py
+++ b/crypto51/config.py
@@ -1,1 +1,1 @@
-coin_blacklist = set(['XDN', 'PPC', 'DGB', 'KMD', 'DCY', 'DP', 'NLG', 'DOGE', 'UNO', 'VIA', 'UBQ', 'GEO', 'XMY', 'FLO', 'FTC', 'PINK', 'CRW'])
+coin_blacklist = set(['XDN', 'PPC', 'DGB', 'KMD', 'DCY', 'DP', 'NLG', 'DOGE', 'UNO', 'VIA', 'UBQ', 'GEO', 'XMY', 'FLO', 'FTC', 'PINK', 'CRW', 'EMC2'])


### PR DESCRIPTION
Einsteinium implemented Komodo's Delayed Proof of Work (dPow) which prevents reverting EMC2 blocks by storing backups onto the Bitcoin ledger.

More info:
https://komodoplatform.com/new-feature-to-verify-dpow-notarizations/
https://komodoplatform.com/security-delayed-proof-of-work-dpow/