### PR TITLE
Remove Siacoin

### DIFF
--- a/crypto51/config.py
+++ b/crypto51/config.py
@@ -1,1 +1,1 @@
-coin_blacklist = set(['XDN', 'PPC', 'DGB', 'KMD', 'DCY', 'DP', 'NLG', 'DOGE', 'UNO', 'VIA', 'UBQ', 'GEO', 'XMY', 'FLO', 'FTC', 'PINK', 'CRW'])
+coin_blacklist = set(['XDN', 'PPC', 'DGB', 'KMD', 'DCY', 'DP', 'NLG', 'DOGE', 'UNO', 'VIA', 'UBQ', 'GEO', 'XMY', 'FLO', 'FTC', 'PINK', 'CRW', 'SC'])


### PR DESCRIPTION
With regards to Siacoin, it looks like your data is pulling correctly for hash rates and market cap, but the 1 hour attack cost is reading $0. I'm guessing this is because Siacoin was recently forked, and your numbers use Nicehash which is not properly calculating how much hashrate they have for Siacoin, or they are and they actually have 0 available.