### PR TITLE
remove GameCredits - has implemented dPoW

### DIFF
--- a/crypto51/config.py
+++ b/crypto51/config.py
@@ -1,1 +1,1 @@
-coin_blacklist = set(['XDN', 'PPC', 'DGB', 'KMD', 'DCY', 'DP', 'NLG', 'DOGE', 'UNO', 'VIA', 'UBQ', 'GEO', 'XMY', 'FLO', 'FTC', 'PINK', 'CRW'])
+coin_blacklist = set(['XDN', 'PPC', 'DGB', 'KMD', 'DCY', 'DP', 'NLG', 'DOGE', 'UNO', 'VIA', 'UBQ', 'GEO', 'XMY', 'FLO', 'FTC', 'PINK', 'CRW', 'GAME'])


### PR DESCRIPTION
GameCredits was the first to implement Komodo's Delayed Proof of Work (dPow) which prevents reverting GAME blocks by storing backups onto the Bitcoin ledger.

More info:
https://komodoplatform.com/new-feature-to-verify-dpow-notarizations/
https://komodoplatform.com/security-delayed-proof-of-work-dpow/

“Currently, there are three external projects using dPoW security: HUSH, GAME Credits, and Einsteinium. Several others are either in the process of being integrated or in talks with the Komodo team to adopt dPoW.”