### PR TITLE
Remove Horizen (ZEN)

### DIFF
--- a/crypto51/config.py
+++ b/crypto51/config.py
@@ -1,1 +1,1 @@
-coin_blacklist = set(['XDN', 'PPC', 'DGB', 'KMD', 'DCY', 'DP', 'NLG', 'DOGE', 'UNO', 'VIA', 'UBQ', 'GEO', 'XMY', 'FLO', 'FTC', 'PINK', 'CRW', 'GAME', 'ZEN'])
+coin_blacklist = set(['XDN', 'PPC', 'DGB', 'KMD', 'DCY', 'DP', 'NLG', 'DOGE', 'UNO', 'VIA', 'UBQ', 'GEO', 'XMY', 'FLO', 'FTC', 'PINK', 'CRW', 'GAME', 'EMC2', 'ZEN'])


### PR DESCRIPTION
To combat fraud, Horizen included an open source penalty mechanism for delayed block reporting within zend 2.0.15 (released 28th September, 2018). The penalty affects actors who try to mine blocks in private and later inject them into the chain. The penalty applied will increase quadratically based upon the number of blocks withheld. 

https://github.com/ZencashOfficial/zen/releases/tag/v2.0.15

A detailed explanation of our quadratic block delay penalty can be found here: https://www.horizen.global/assets/files/A-Penalty-System-for-Delayed-Block-Submission-by-Horizen.pdf

Thanks for helping to provide clarity to the industry. 