### PR TITLE
Remove Zcoin

### DIFF
--- a/crypto51/config.py
+++ b/crypto51/config.py
@@ -1,1 +1,1 @@
-coin_blacklist = set(['XDN', 'PPC', 'DGB', 'KMD', 'DCY', 'DP', 'NLG', 'DOGE', 'UNO', 'VIA', 'UBQ', 'GEO', 'XMY', 'FLO', 'FTC', 'PINK', 'CRW', 'GAME', 'EMC2'])
+coin_blacklist = set(['XDN', 'PPC', 'DGB', 'KMD', 'DCY', 'DP', 'NLG', 'DOGE', 'UNO', 'VIA', 'UBQ', 'GEO', 'XMY', 'FLO', 'FTC', 'PINK', 'CRW', 'GAME', 'EMC2', 'XZC'])


### PR DESCRIPTION
Since we have transitioned to our new PoW algo MTP yesterday, the site is showing misleading information based on the old algorithm Lyra2z. Also there is no Nicehash support for our algorithm and we don't expect them to offer it any time soon.
Hence I am requesting removal from the site.