### PR TITLE
Remove MUE

### DIFF
--- a/crypto51/config.py
+++ b/crypto51/config.py
@@ -1,1 +1,1 @@
-coin_blacklist = set(['XDN', 'PPC', 'DGB', 'KMD', 'DCY', 'DP', 'NLG', 'DOGE', 'UNO', 'VIA', 'UBQ', 'GEO', 'XMY', 'FLO', 'FTC', 'PINK', 'CRW', 'GAME', 'EMC2'])
+coin_blacklist = set(['XDN', 'PPC', 'DGB', 'KMD', 'DCY', 'DP', 'NLG', 'DOGE', 'UNO', 'VIA', 'UBQ', 'GEO', 'XMY', 'FLO', 'FTC', 'PINK', 'CRW', 'GAME', 'EMC2', 'MUE'])


### PR DESCRIPTION
MUE is no longer a POW coin, and has moved to a PoS fork of PivX and Phore.

Please remove MUE from the 51% app as it no longer applies to MonetaryUnit. Thank you!