### PR TITLE
Remove QRL

### DIFF
--- a/crypto51/config.py
+++ b/crypto51/config.py
@@ -1,1 +1,1 @@
-coin_blacklist = set(['XDN', 'PPC', 'DGB', 'KMD', 'DCY', 'DP', 'NLG', 'DOGE', 'UNO', 'VIA', 'UBQ', 'GEO', 'XMY', 'FLO', 'FTC', 'PINK', 'CRW', 'GAME', 'EMC2', 'MUE', 'XZC', 'ZEN', 'CANN'])
+coin_blacklist = set(['XDN', 'PPC', 'DGB', 'KMD', 'DCY', 'DP', 'NLG', 'DOGE', 'UNO', 'VIA', 'UBQ', 'GEO', 'XMY', 'FLO', 'FTC', 'PINK', 'CRW', 'GAME', 'EMC2', 'MUE', 'XZC', 'ZEN', 'CANN', 'QRL'])


### PR DESCRIPTION
Hello,

QRL hash rate on minethecoin.com is invalid. Real hash rate can be found here: https://miningpoolstats.stream/quantumrl.

Please remove QRL from the 51% app. 

Thank you!