### PR TITLE
Retire mtc & cmc for wtm

### DIFF
--- a/crypto51/apis/nicehash.py
+++ b/crypto51/apis/nicehash.py
@@ -1,7 +1,7 @@
 import requests
 
 
-# Nicehash name on left, mtc on right
+# Nicehash name on left, wtm on right
 remap_algorithms = {
     'daggerhashimoto': 'ethash',
     'sha256asicboost': 'sha256'

--- a/crypto51/apis/wtm.py
+++ b/crypto51/apis/wtm.py
@@ -1,0 +1,58 @@
+import requests
+import json
+import time
+
+class WTM:
+    def __init__(self):
+        self._wtm = {}
+
+        print("Getting whattomine data")
+        wtm = requests.get('https://whattomine.com/calculators.json').json()
+
+        print("Filter out lagging coins from whattomine data")
+        # print(json.dumps(wtm, indent=2))
+
+        # Filter out 'lagging'
+        for coin in wtm["coins"]:
+            print("Grabbing more data for "+coin)
+            if wtm["coins"][coin]['lagging'] == False and wtm["coins"][coin]['status'] == "Active":
+                print("-> Coin isn't lagging and is active")
+
+                # Grab *more* data from WTM
+                wtmlink = 'https://whattomine.com/coins/'+str(wtm['coins'][coin]['id'])+'.json'
+                wtmcoin = requests.get(wtmlink).json()
+
+                if 'errors' in wtmcoin:
+                    print(wtmcoin['errors'])
+                    continue
+
+                self._wtm[wtm["coins"][coin]['tag']] = {
+                    "id":wtm["coins"][coin]['id'],
+                    "name":wtmcoin["name"],
+                    "symbol":wtm["coins"][coin]['tag'],
+                    "algorithm":wtm["coins"][coin]['algorithm'],
+                    "marketcap":float(wtmcoin["market_cap"].replace("$", '').replace(',','')),
+                    "exchange_rate":wtmcoin["exchange_rate"],
+                    "hashrate":wtmcoin["nethash"]
+                }
+                time.sleep(0.5)
+
+    def get_coin_data(self):
+        return self._wtm
+
+    def get_coin_details(self, symbol):
+        return self._wtm[symbol]
+
+    def _get_h_hash_rate(self, text):
+        """Convert the hash rate string to a h/s hash rate."""
+        value, units = text.split(' ')
+        value = float(value.replace(',', ''))
+        if units == 'KH/s':
+            return value * (1000.0 ** 1)
+        elif units == 'MH/s':
+            return value * (1000.0 ** 2)
+        elif units == 'GH/s':
+            return value * (1000.0 ** 3)
+        elif units == 'TH/s':
+            return value * (1000.0 ** 4)
+        raise Exception('Unknown units: {}'.format(units))

--- a/crypto51/app.py
+++ b/crypto51/app.py
@@ -1,74 +1,75 @@
 import datetime
 import json
+import requests
 
-from crypto51.apis.mtc import MTC
-from crypto51.apis.nicehash import NiceHash
-from crypto51.apis.cmc import CMC
-from crypto51.libs import common
-from crypto51 import config
-
+import config
+from apis.wtm import WTM
+from apis.nicehash import NiceHash
+from libs import common
 
 if __name__ == '__main__':
-    mtc = MTC()
+ 
     nh = NiceHash()
-    cmc = CMC()
-    listings = cmc.get_listings()
-    btc_price = listings['BTC']['price']
-    coins = []
-    for coin in mtc.get_coins():
+    wtm = WTM()
+    coins = wtm.get_coin_data()
+    allcoins = [];
+    btc_price = requests.get('https://whattomine.com/coins/1.json').json()['exchange_rate'];
+
+    # Iterate through coins on WTM that's not 'lagging'
+    for coin in coins:
+        coin_id = coins[coin]['id']
+        coin_name = coins[coin]['name']
+        coin_symbol = coins[coin]['symbol']
+        coin_hashrate = coins[coin]['hashrate']
+        coin_marketcap = coins[coin]['marketcap']
+        coin_algorithm = coins[coin]['algorithm']
+        coin_exchange_rate = coins[coin]['exchange_rate']
+
         # Certain coins have invalid hash rates or other values, so we skip them
-        if coin['symbol'] in config.coin_blacklist:
+        if coin_symbol in config.coin_blacklist:
             continue
 
-        mining_details = mtc.get_details(coin['link'])
-        cost = nh.get_cost_global(mining_details['algorithm'], mining_details['hash_rate'])
-        nh_hash_ratio = nh.get_hash_percentage(mining_details['algorithm'], mining_details['hash_rate'])
+        # Get mining details from WTM
+        # Details are: hash_rate, algorithm
+        cost = nh.get_cost_global(coin_algorithm, coin_hashrate)
+        nh_hash_ratio = nh.get_hash_percentage(coin_algorithm, coin_hashrate);
 
         # Skip coins that NiceHash doesn't support
         if cost is None:
-            continue
-
-        # Skip anything not in cmc for now
-        listing = listings.get(coin['symbol'])
-        if not listing:
+            print("!!! Skipping {} because of {}".format(coin_symbol, coin_algorithm))
             continue
 
         # TODO: Add this to the coin blacklist.
-        if coin['name'] == 'Bitgem':
+        if coin_name == 'Bitgem':
             continue
 
-        print(coin)
-        print(mining_details)
-        print(cost)
+        rentable_capacity = nh.get_capacity(coin_algorithm)
+        rentable_price_btc = nh.get_algorithm_price(coin_algorithm)
 
-        rentable_capacity = nh.get_capacity(mining_details['algorithm'])
-        rentable_price_btc = nh.get_algorithm_price(mining_details['algorithm'])
-        coins.append({
-            'symbol': coin['symbol'],
-            'name': coin['name'],
-            'minethecoin_link': coin['link'],
-            'algorithm': mining_details['algorithm'],
-            'market_cap': listing['market_cap'],
-            'market_cap_pretty': common.get_pretty_money(listing['market_cap']),
-            'coinmarketcap_rank': listing['rank'],
-            'coinmarketcap_link': 'https://www.coinmarketcap.com/currencies/{}'.format(listing['website_slug']),
-            'hash_rate': mining_details['hash_rate'],
-            'hash_rate_pretty': common.get_pretty_hash_rate(mining_details['hash_rate']),
+        allcoins.append({
+            'symbol': coin_symbol,
+            'name': coin_name,
+            'minethecoin_link': "https://google.com",
+            'algorithm': coin_algorithm,
+            'market_cap': coin_marketcap,
+            'market_cap_pretty': common.get_pretty_money(coin_marketcap),
+            'hash_rate': coin_hashrate,
+            'hash_rate_pretty': common.get_pretty_hash_rate(coin_hashrate),
             'rentable_capacity': rentable_capacity,
             'rentable_capacity_pretty': common.get_pretty_hash_rate(rentable_capacity),
-            'nicehash_market_link': 'https://www.nicehash.com/marketplace/{}'.format(nh.get_algorithm_name(mining_details['algorithm'])),
+            'nicehash_market_link': 'https://www.nicehash.com/marketplace/{}'.format(nh.get_algorithm_name(coin_algorithm)),
             'attack_hourly_cost': cost * btc_price / 24.0 if cost != 0 else '?',
             'attack_hourly_cost_pretty': '${:,.0f}'.format(cost * btc_price / 24.0) if cost != 0 else '?',
             'network_vs_rentable_ratio': nh_hash_ratio,
             'rentable_price_btc': rentable_price_btc,
-            'rentable_price_units': nh.get_units(mining_details['algorithm']),
+            'rentable_price_units': nh.get_units(coin_algorithm),
             'rentable_price_usd_hour': '${:,.2f}'.format(rentable_price_btc * btc_price / 24.0)
         })
 
     # Sort by rank
     results = {
         'last_updated': datetime.datetime.utcnow().isoformat(),
-        'coins': sorted(coins, key=lambda k: k['coinmarketcap_rank'])
+        'coins': sorted(allcoins, key=lambda k: k['market_cap'], reverse=True)
     }
 
     with open('dist/coins.json', 'w') as f:


### PR DESCRIPTION
Retires minethecoin whose author can't be reached to fix hashrate and replaces it with wtm (what to mine) which likely grabs marketcap data from cmc anyway. Data is sorted by marketcap.

**Benefits**

- Whattomine is more active in being a data authority in the space so their data is reliable
- Less dependencies should API change down the line
- Fixes hashrate data for various coins like QRL
- CMC now requires a key, which means porting around environment variables, this avoids that.

Seeing as that crypto51.app is becoming a resource that cryptocurrency news agencies rely upon, it's important that the data that it reflects is accurate or it will lose authority and credibility in the space with a more accurate site that supersedes it.