### PR TITLE
Updated URLs and timeliness of About page

### DIFF
--- a/src/about.html
+++ b/src/about.html
@@ -63,14 +63,15 @@
       them, making it extremely expensive to acquire the necessary
       hardware to pull an attack like this off. Smaller cryptocurrencies have
       less hashing power securing the network, making it possible to simply
-      rent hashing power from miners on a service like <a href="#">Nicehash</a>
+      rent hashing power from miners on a service like <a target="_blank"
+                                    href="https://www.nicehash.com/">Nicehash</a>
       for a few hours. This significantly reduces the capital costs of an
       attack.</p>
-      <p>In recent weeks there have been a number of 51% attacks including a <a
+      <p>Recently there have been a number of 51% attacks including a <a
                                                           target="_blank"
                                                           href="https://qz.com/1287701/bitcoin-golds-51-attack-is-every-cryptocurrencys-nightmare-scenario/">high
                                                           profile attack</a>
-      against Bitcoin Gold a few days ago where $18 Million was stolen.</p>
+      against Bitcoin Gold where $18 Million was stolen.</p>
       <h2>How is the attack cost calculated?</h2>
       <p>Using the prices NiceHash lists for different algorithms we are able
       to calculate how much it would cost to rent enough hashing power to match
@@ -89,8 +90,8 @@
       </ul>
       <h2>Where is the data from?</h2>
       <p>Hash rates are from <a target="_blank"
-                                href="https://minethecoin.com">Mine the
-                                Coin</a>, coin prices are from <a
+                                href="https://whattomine.com/">What to
+                                Mine</a>, coin prices are from <a
                                 target="_blank"
                                 href="https://www.coinmarketcap.com">CoinMarketCap</a>,
       and rental pricing is from <a target="_blank"


### PR DESCRIPTION
The documentation still refers to Mine The Coin even though the app now uses What To Hash. Also added a missing URL and changed the timeliness of one sentence.