### PR TITLE
Remove DASH

### DIFF
--- a/crypto51/config.py
+++ b/crypto51/config.py
@@ -1,1 +1,1 @@
-coin_blacklist = set(['XDN', 'PPC', 'DGB', 'KMD', 'DCY', 'DP', 'NLG', 'DOGE', 'UNO', 'VIA', 'UBQ', 'GEO', 'XMY', 'FLO', 'FTC', 'PINK', 'CRW', 'GAME', 'EMC2', 'MUE', 'XZC', 'ZEN', 'CANN'])
+coin_blacklist = set(['XDN', 'PPC', 'DGB', 'KMD', 'DCY', 'DP', 'NLG', 'DOGE', 'UNO', 'VIA', 'UBQ', 'GEO', 'XMY', 'FLO', 'FTC', 'PINK', 'CRW', 'GAME', 'EMC2', 'MUE', 'XZC', 'ZEN', 'CANN', 'DASH'])


### PR DESCRIPTION
It is actually not possible anymore, as having 51% of the hashrate is no longer sufficient. 
See more here : https://blog.dash.org/mitigating-51-attacks-with-llmq-based-chainlocks-7266aa648ec9