### PR TITLE
adds randomx to algorithm remapping. Fixes randomx being skipped.

### DIFF
--- a/crypto51/apis/nicehash.py
+++ b/crypto51/apis/nicehash.py
@@ -4,6 +4,7 @@ import requests
 # Nicehash name on left, wtm on right
 remap_algorithms = {
     'daggerhashimoto': 'ethash',
+    'randomxmonero': 'randomx'
 }
 
 


### PR DESCRIPTION
Monero is not currently listed as the nicehash algorithm name differs from the what to mine name.
